### PR TITLE
Fixes a bug in health check with service pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ The health command checks if the ECS cluster is healthy by checking whether:
 ```bash
 cloud-compose ecs health
 ```
+
+The `--verbose` flag optionally enables detailed information about which services or load balancers are unhealthy.

--- a/cloudcompose/ecs/commands/cli.py
+++ b/cloudcompose/ecs/commands/cli.py
@@ -37,7 +37,8 @@ def down(force):
 
 
 @cli.command()
-def health():
+@click.option('--verbose/--no-verbose', default=False, help="Output detailed health check information")
+def health(verbose):
     """
     check ECS cluster health
     """
@@ -45,7 +46,7 @@ def health():
         cloud_config = CloudConfig()
         controller = Controller(cloud_config)
         name = cloud_config.config_data('cluster')['name']
-        healthy = controller.cluster_health()
+        healthy = controller.cluster_health(verbose)
         if healthy:
             print("{} is healthy".format(name))
         else:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ import warnings
 
 setup(
     name='cloud-compose-ecs',
-    version='0.1.0',
+    version='0.1.1',
+    description='ECS plugin for cloud-compose',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This fixes an issue with ECS clusters that run more than 10 unique services, as the ECS API only returns a maximum of 10 services at a time.  The previous implementation did not follow the API's pagination to retrieve all services running on the cluster, which can potentially cause an outage if the cluster is cycled too quickly.

This also adds a --verbose flag to the health check which can be useful for troubleshooting which service/load balancer is unhealthy.