### PR TITLE
Add retry while scaling

### DIFF
--- a/cloudcompose/ecs/controller.py
+++ b/cloudcompose/ecs/controller.py
@@ -105,7 +105,7 @@ class Controller(object):
         else:
             print("Starting upgrade of container instances:")
             while workflow.step():
-                sleep(10)
+                sleep(60)
 
     def is_fully_scaled(self):
         """


### PR DESCRIPTION
The immediate exit logic on failure is too aggressive when containers need to be shuffled on ECS instances. This is especially noticeable on clusters where the services run at the same scale as the cluster, so container instances need to be moved to another ECS instance.

This fixes the case where a new ECS instance comes online (which satisfies the desired count for the ECS cluster), but the services are not healthy because containers are still starting up or are still being registered in the load balancer.

Each ECS instance is allowed 3 retries before the upgrade process is terminated.